### PR TITLE
Make 'person first name' non-mandatory

### DIFF
--- a/scripts/ot_export_atlas_baseline_exp.py
+++ b/scripts/ot_export_atlas_baseline_exp.py
@@ -321,7 +321,7 @@ def get_provider(idf_dict):
     'BLUEPRINT consortium; ArrayExpress'
     """
 
-    f"{idf_dict['person last name']}, {idf_dict['person first name']}"
+    # f"{idf_dict['person last name']}, {idf_dict['person first name']}"
     first_names = []
     if 'person first name' in idf_dict:
         first_names = idf_dict['person first name'].split("\t")


### PR DESCRIPTION
Error in log like below is observed:
`E-ERAD-169  has KeyError: 'person first name'`

And that field is from an experiment IDF file.  Change here removes the line that makes `person first name` mandatory, when it should not be.